### PR TITLE
Rb/get config rework

### DIFF
--- a/common-utils/src/main/java/eu/arrowhead/common/Constants.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/Constants.java
@@ -97,20 +97,34 @@ public final class Constants {
 	public static final String X_509 = "X.509";
 	public static final String SERVER_SSL_ENABLED = "server.ssl.enabled";
 	public static final String $SERVER_SSL_ENABLED_WD = "${" + SERVER_SSL_ENABLED + ":" + Defaults.SERVER_SSL_ENABLED_DEFAULT + "}";
-	public static final String KEYSTORE_TYPE = "server.ssl.key-store-type";
-	public static final String $KEYSTORE_TYPE_WD = "${" + KEYSTORE_TYPE + ":" + Defaults.KEYSTORE_TYPE_DEFAULT + "}";
-	public static final String KEYSTORE_PATH = "server.ssl.key-store";
-	public static final String $KEYSTORE_PATH_WD = "${" + KEYSTORE_PATH + ":" + Defaults.KEYSTORE_PATH_DEFAULT + "}";
-	public static final String KEYSTORE_PASSWORD = "server.ssl.key-store-password";
-	public static final String $KEYSTORE_PASSWORD_WD = "${" + KEYSTORE_PASSWORD + ":" + Defaults.KEYSTORE_PASSWORD_DEFAULT + "}";
-	public static final String KEY_PASSWORD = "server.ssl.key-password";
-	public static final String $KEY_PASSWORD_WD = "${" + KEY_PASSWORD + ":" + Defaults.KEY_PASSWORD_DEFAULT + "}";
-	public static final String KEY_ALIAS = "server.ssl.key-alias";
-	public static final String $KEY_ALIAS_WD = "${" + KEY_ALIAS + ":" + Defaults.KEY_ALIAS_DEFAULT + "}";
-	public static final String TRUSTSTORE_PATH = "server.ssl.trust-store";
-	public static final String $TRUSTSTORE_PATH_WD = "${" + TRUSTSTORE_PATH + ":" + Defaults.TRUSTSTORE_PATH_DEFAULT + "}";
-	public static final String TRUSTSTORE_PASSWORD = "server.ssl.trust-store-password";
-	public static final String $TRUSTSTORE_PASSWORD_WD = "${" + TRUSTSTORE_PASSWORD + ":" + Defaults.TRUSTSTORE_PASSWORD_DEFAULT + "}";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__STORE__TYPE = "server.ssl.key-store-type";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String $SERVER_SSL_KEY__STORE_TYPE_WD = "${" + SERVER_SSL_KEY__STORE__TYPE + ":" + Defaults.SERVER_SSL_KEY__STORE__TYPE_DEFAULT + "}";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__STORE = "server.ssl.key-store";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String $SERVER_SSL_KEY__STORE_WD = "${" + SERVER_SSL_KEY__STORE + ":" + Defaults.SERVER_SSL_KEY__STORE_DEFAULT + "}";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__STORE__PASSWORD = "server.ssl.key-store-password";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String $SERVER_SSL_KEY__STORE__PASSWORD_WD = "${" + SERVER_SSL_KEY__STORE__PASSWORD + ":" + Defaults.SERVER_SSL_KEY__STORE__PASSWORD_DEFAULT + "}";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__PASSWORD = "server.ssl.key-password";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String $SERVER_SSL_KEY__PASSWORD_WD = "${" + SERVER_SSL_KEY__PASSWORD + ":" + Defaults.SERVER_SSL_KEY__PASSWORD_DEFAULT + "}";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__ALIAS = "server.ssl.key-alias";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String $SERVER_SSL_KEY__ALIAS_WD = "${" + SERVER_SSL_KEY__ALIAS + ":" + Defaults.SERVER_SSL_KEY__ALIAS_DEFAULT + "}";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_TRUST__STORE = "server.ssl.trust-store";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String $SERVER_SSL_TRUST__STORE_WD = "${" + SERVER_SSL_TRUST__STORE + ":" + Defaults.SERVER_SSL_TRUST__STORE_DEFAULT + "}";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_TRUST__STORE__PASSWORD = "server.ssl.trust-store-password";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String $SERVER_SSL_TRUST__STORE__PASSWORD_WD = "${" + SERVER_SSL_TRUST__STORE__PASSWORD + ":" + Defaults.SERVER_SSL_TRUST__STORE__PASSWORD_DEFAULT + "}";
 	public static final String DISABLE_HOSTNAME_VERIFIER = "disable.hostname.verifier";
 	public static final String $DISABLE_HOSTNAME_VERIFIER_WD = "${" + DISABLE_HOSTNAME_VERIFIER + ":" + Defaults.DISABLE_HOSTNAME_VERIFIER_DEFAULT + "}";
 

--- a/common-utils/src/main/java/eu/arrowhead/common/Constants.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/Constants.java
@@ -88,6 +88,7 @@ public final class Constants {
 	public static final String ENABLE_BLACKLIST_FILTER = "enable.blacklist.filter";
 	public static final String FORCE_BLACKLIST_FILTER = "force.blacklist.filter";
 	public static final String $FORCE_BLACKLIST_FILTER_WD = "${" + FORCE_BLACKLIST_FILTER + ":" + Defaults.FORCE_BLACKLIST_FILTER_DEFAULT + "}";
+	public static final String SERVICE_ADDRESS_ALIAS = "service.address.alias";
 
 	public static final String METADATA_KEY_X509_PUBLIC_KEY = "x509-public-key";
 

--- a/common-utils/src/main/java/eu/arrowhead/common/Constants.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/Constants.java
@@ -49,7 +49,7 @@ public final class Constants {
 	public static final long CONVERSION_MILLISECOND_TO_MINUTE = 60000;
 
 	public static final String MAX_PAGE_SIZE = "max.page.size";
-	public static final String $MAX_PAGE_SIZE_WD = "${" + MAX_PAGE_SIZE + ":1000}";
+	public static final String $MAX_PAGE_SIZE_WD = "${" + MAX_PAGE_SIZE + ":" + Defaults.MAX_PAGE_SIZE_DEFAULT + "}";
 
 	// System related
 
@@ -63,31 +63,31 @@ public final class Constants {
 	public static final String DATABASE_PASSWORD = "spring.datasource.password";
 	public static final String DATABASE_DRIVER_CLASS = "spring.datasource.driver-class-name";
 	public static final String SERVER_ADDRESS = "server.address";
-	public static final String $SERVER_ADDRESS = "${" + SERVER_ADDRESS + ":}";
+	public static final String $SERVER_ADDRESS = "${" + SERVER_ADDRESS + ":" + Defaults.SERVER_ADDRESS_DEFAULT + "}";
 	public static final String SERVER_PORT = "server.port";
-	public static final String $SERVER_PORT = "${" + SERVER_PORT + ":0}";
+	public static final String $SERVER_PORT = "${" + SERVER_PORT + ":" + Defaults.SERVER_PORT_DEFAULT + "}";
 	public static final String DOMAIN_NAME = "domain.name";
-	public static final String $DOMAIN_NAME = "${" + DOMAIN_NAME + ":}";
+	public static final String $DOMAIN_NAME = "${" + DOMAIN_NAME + ":" + Defaults.DOMAIN_NAME_DEFAULT + "}";
 	public static final String SERVICEREGISTRY_ADDRESS = "service.registry.address";
-	public static final String $SERVICEREGISTRY_ADDRESS_WD = "${" + SERVICEREGISTRY_ADDRESS + ":" + LOCALHOST + "}";
+	public static final String $SERVICEREGISTRY_ADDRESS_WD = "${" + SERVICEREGISTRY_ADDRESS + ":" + Defaults.SERVICEREGISTRY_ADDRESS_DEFAULT + "}";
 	public static final String SERVICEREGISTRY_PORT = "service.registry.port";
-	public static final String $SERVICEREGISTRY_PORT_WD = "${" + SERVICEREGISTRY_PORT + ":8443}";
+	public static final String $SERVICEREGISTRY_PORT_WD = "${" + SERVICEREGISTRY_PORT + ":" + Defaults.SERVICEREGISTRY_PORT_DEFAULT + "}";
 	public static final String AUTHENTICATION_POLICY = "authentication.policy";
-	public static final String $AUTHENTICATION_POLICY_WD = "${" + AUTHENTICATION_POLICY + ":CERTIFICATE}";
+	public static final String $AUTHENTICATION_POLICY_WD = "${" + AUTHENTICATION_POLICY + ":" + Defaults.AUTHENTICATION_POLICY_DEFAULT + "}";
 	public static final String ENABLE_MANAGEMENT_FILTER = "enable.management.filter";
 	public static final String MANAGEMENT_POLICY = "management.policy";
-	public static final String $MANAGEMENT_POLICY = "${" + MANAGEMENT_POLICY + ":SYSOP_ONLY}";
+	public static final String $MANAGEMENT_POLICY = "${" + MANAGEMENT_POLICY + ":" + Defaults.MANAGEMENT_POLICY_DEFAULT + "}";
 	public static final String MANAGEMENT_WHITELIST = "management.whitelist";
-	public static final String $MANAGEMENT_WHITELIST = "${" + MANAGEMENT_WHITELIST + ":\"\"}";
+	public static final String $MANAGEMENT_WHITELIST = "${" + MANAGEMENT_WHITELIST + ":" + Defaults.MANAGEMENT_WHITELIST_DEFAULT + "}";
 	public static final String ALLOW_SELF_ADDRESSING = "allow.self.addressing";
-	public static final String $ALLOW_SELF_ADDRESSING_WD = "${" + ALLOW_SELF_ADDRESSING + ":true}";
+	public static final String $ALLOW_SELF_ADDRESSING_WD = "${" + ALLOW_SELF_ADDRESSING + ":" + Defaults.ALLOW_SELF_ADDRESSING_DEFAULT + "}";
 	public static final String ALLOW_NON_ROUTABLE_ADDRESSING = "allow.non.routable.addressing";
-	public static final String $ALLOW_NON_ROUTABLE_ADDRESSING_WD = "${" + ALLOW_NON_ROUTABLE_ADDRESSING + ":true}";
+	public static final String $ALLOW_NON_ROUTABLE_ADDRESSING_WD = "${" + ALLOW_NON_ROUTABLE_ADDRESSING + ":" + Defaults.ALLOW_NON_ROUTABLE_ADDRESSING_DEFAULT + "}";
 	public static final String HTTP_COLLECTOR_MODE = "http.collector.mode";
-	public static final String $HTTP_COLLECTOR_MODE_WD = "${" + HTTP_COLLECTOR_MODE + ":SR_AND_ORCH}";
+	public static final String $HTTP_COLLECTOR_MODE_WD = "${" + HTTP_COLLECTOR_MODE + ":" + Defaults.HTTP_COLLECTOR_MODE_DEFAULT + "}";
 	public static final String ENABLE_BLACKLIST_FILTER = "enable.blacklist.filter";
 	public static final String FORCE_BLACKLIST_FILTER = "force.blacklist.filter";
-	public static final String $FORCE_BLACKLIST_FILTER_WD = "${" + FORCE_BLACKLIST_FILTER + ":true}";
+	public static final String $FORCE_BLACKLIST_FILTER_WD = "${" + FORCE_BLACKLIST_FILTER + ":" + Defaults.FORCE_BLACKLIST_FILTER_DEFAULT + "}";
 
 	public static final String METADATA_KEY_X509_PUBLIC_KEY = "x509-public-key";
 
@@ -95,23 +95,23 @@ public final class Constants {
 
 	public static final String X_509 = "X.509";
 	public static final String SERVER_SSL_ENABLED = "server.ssl.enabled";
-	public static final String $SERVER_SSL_ENABLED_WD = "${" + SERVER_SSL_ENABLED + ":false}";
+	public static final String $SERVER_SSL_ENABLED_WD = "${" + SERVER_SSL_ENABLED + ":" + Defaults.SERVER_SSL_ENABLED_DEFAULT + "}";
 	public static final String KEYSTORE_TYPE = "server.ssl.key-store-type";
-	public static final String $KEYSTORE_TYPE_WD = "${" + KEYSTORE_TYPE + ":" + PKCS12 + "}";
+	public static final String $KEYSTORE_TYPE_WD = "${" + KEYSTORE_TYPE + ":" + Defaults.KEYSTORE_TYPE_DEFAULT + "}";
 	public static final String KEYSTORE_PATH = "server.ssl.key-store";
-	public static final String $KEYSTORE_PATH_WD = "${" + KEYSTORE_PATH + ":}";
+	public static final String $KEYSTORE_PATH_WD = "${" + KEYSTORE_PATH + ":" + Defaults.KEYSTORE_PATH_DEFAULT + "}";
 	public static final String KEYSTORE_PASSWORD = "server.ssl.key-store-password";
-	public static final String $KEYSTORE_PASSWORD_WD = "${" + KEYSTORE_PASSWORD + ":}";
+	public static final String $KEYSTORE_PASSWORD_WD = "${" + KEYSTORE_PASSWORD + ":" + Defaults.KEYSTORE_PASSWORD_DEFAULT + "}";
 	public static final String KEY_PASSWORD = "server.ssl.key-password";
-	public static final String $KEY_PASSWORD_WD = "${" + KEY_PASSWORD + ":}";
+	public static final String $KEY_PASSWORD_WD = "${" + KEY_PASSWORD + ":" + Defaults.KEY_PASSWORD_DEFAULT + "}";
 	public static final String KEY_ALIAS = "server.ssl.key-alias";
-	public static final String $KEY_ALIAS_WD = "${" + KEY_ALIAS + ":}";
+	public static final String $KEY_ALIAS_WD = "${" + KEY_ALIAS + ":" + Defaults.KEY_ALIAS_DEFAULT + "}";
 	public static final String TRUSTSTORE_PATH = "server.ssl.trust-store";
-	public static final String $TRUSTSTORE_PATH_WD = "${" + TRUSTSTORE_PATH + ":}";
+	public static final String $TRUSTSTORE_PATH_WD = "${" + TRUSTSTORE_PATH + ":" + Defaults.TRUSTSTORE_PATH_DEFAULT + "}";
 	public static final String TRUSTSTORE_PASSWORD = "server.ssl.trust-store-password";
-	public static final String $TRUSTSTORE_PASSWORD_WD = "${" + TRUSTSTORE_PASSWORD + ":}";
+	public static final String $TRUSTSTORE_PASSWORD_WD = "${" + TRUSTSTORE_PASSWORD + ":" + Defaults.TRUSTSTORE_PASSWORD_DEFAULT + "}";
 	public static final String DISABLE_HOSTNAME_VERIFIER = "disable.hostname.verifier";
-	public static final String $DISABLE_HOSTNAME_VERIFIER_WD = "${" + DISABLE_HOSTNAME_VERIFIER + ":false}";
+	public static final String $DISABLE_HOSTNAME_VERIFIER_WD = "${" + DISABLE_HOSTNAME_VERIFIER + ":" + Defaults.DISABLE_HOSTNAME_VERIFIER_DEFAULT + "}";
 
 	// HTTP related
 
@@ -135,11 +135,11 @@ public final class Constants {
 	public static final String HTTP_HEADER_AUTHORIZATION_PREFIX_AUTH_TOKEN = "AUTH-TOKEN";
 
 	public static final String HTTP_CLIENT_CONNECTION_TIMEOUT = "http.client.connection.timeout";
-	public static final String $HTTP_CLIENT_CONNECTION_TIMEOUT_WD = "${" + HTTP_CLIENT_CONNECTION_TIMEOUT + ":30000}";
+	public static final String $HTTP_CLIENT_CONNECTION_TIMEOUT_WD = "${" + HTTP_CLIENT_CONNECTION_TIMEOUT + ":" + Defaults.HTTP_CLIENT_CONNECTION_TIMEOUT_DEFAULT + "}";
 	public static final String HTTP_CLIENT_SOCKET_TIMEOUT = "http.client.socket.timeout";
-	public static final String $HTTP_CLIENT_SOCKET_TIMEOUT_WD = "${" + HTTP_CLIENT_SOCKET_TIMEOUT + ":30000}";
+	public static final String $HTTP_CLIENT_SOCKET_TIMEOUT_WD = "${" + HTTP_CLIENT_SOCKET_TIMEOUT + ":" + Defaults.HTTP_CLIENT_SOCKET_TIMEOUT_DEFAULT + "}";
 	public static final String LOG_ALL_REQUEST_AND_RESPONSE = "log.all.request.and.response";
-	public static final String $LOG_ALL_REQUEST_AND_RESPONSE_WD = "${" + LOG_ALL_REQUEST_AND_RESPONSE + ":false}";
+	public static final String $LOG_ALL_REQUEST_AND_RESPONSE_WD = "${" + LOG_ALL_REQUEST_AND_RESPONSE + ":" + Defaults.LOG_ALL_REQUEST_AND_RESPONSE_DEFAULT + "}";
 
 	// Swagger
 
@@ -160,9 +160,8 @@ public final class Constants {
 
 	public static final long CORS_MAX_AGE = 600;
 	public static final boolean CORS_ALLOW_CREDENTIALS = true;
-	public static final String DEFAULT_CORS_ORIGIN_PATTERN = "*";
 	public static final String CORS_ORIGIN_PATTERNS = "cors.origin.patterns";
-	public static final String $CORS_ORIGIN_PATTERNS_WD = "${" + CORS_ORIGIN_PATTERNS + ":*}";
+	public static final String $CORS_ORIGIN_PATTERNS_WD = "${" + CORS_ORIGIN_PATTERNS + ":" + Defaults.CORS_ORIGIN_PATTERN_DEFAULT + "}";
 
 	// MQTT related
 
@@ -176,13 +175,13 @@ public final class Constants {
 	public static final int MQTT_DEFAULT_QOS = 0;
 
 	public static final String MQTT_API_ENABLED = "mqtt.api.enabled";
-	public static final String $MQTT_API_ENABLED_WD = "${" + MQTT_API_ENABLED + ":false}";
+	public static final String $MQTT_API_ENABLED_WD = "${" + MQTT_API_ENABLED + ":" + Defaults.MQTT_API_ENABLED_DEFAULT + "}";
 	public static final String MQTT_BROKER_ADDRESS = "mqtt.broker.address";
-	public static final String $MQTT_BROKER_ADDRESS_WD = "${" + MQTT_BROKER_ADDRESS + ":}";
+	public static final String $MQTT_BROKER_ADDRESS_WD = "${" + MQTT_BROKER_ADDRESS + ":" + Defaults.MQTT_BROKER_ADDRESS_DEFAULT + "}";
 	public static final String MQTT_BROKER_PORT = "mqtt.broker.port";
-	public static final String $MQTT_BROKER_PORT_WD = "${" + MQTT_BROKER_PORT + ":1883}";
+	public static final String $MQTT_BROKER_PORT_WD = "${" + MQTT_BROKER_PORT + ":" + Defaults.MQTT_BROKER_PORT_DEFAULT + "}";
 	public static final String MQTT_CLIENT_PASSWORD = "mqtt.client.password";
-	public static final String $MQTT_CLIENT_PASSWORD = "${" + MQTT_CLIENT_PASSWORD + ":123456}";
+	public static final String $MQTT_CLIENT_PASSWORD = "${" + MQTT_CLIENT_PASSWORD + ":" + Defaults.MQTT_CLIENT_PASSWORD_DEFAULT + "}";
 
 	// Service related
 

--- a/common-utils/src/main/java/eu/arrowhead/common/Defaults.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/Defaults.java
@@ -34,13 +34,20 @@ public class Defaults {
 	// SSL related
 
 	public static final String SERVER_SSL_ENABLED_DEFAULT = "false";
-	public static final String KEYSTORE_TYPE_DEFAULT = Constants.PKCS12;
-	public static final String KEYSTORE_PATH_DEFAULT = "";
-	public static final String KEYSTORE_PASSWORD_DEFAULT = "";
-	public static final String KEY_PASSWORD_DEFAULT = "";
-	public static final String KEY_ALIAS_DEFAULT = "";
-	public static final String TRUSTSTORE_PATH_DEFAULT = "";
-	public static final String TRUSTSTORE_PASSWORD_DEFAULT = "";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__STORE__TYPE_DEFAULT = Constants.PKCS12;
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__STORE_DEFAULT = "";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__STORE__PASSWORD_DEFAULT = "";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__PASSWORD_DEFAULT = "";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_KEY__ALIAS_DEFAULT = "";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_TRUST__STORE_DEFAULT = "";
+	@SuppressWarnings("checkstyle:ConstantName")
+	public static final String SERVER_SSL_TRUST__STORE__PASSWORD_DEFAULT = "";
 	public static final String DISABLE_HOSTNAME_VERIFIER_DEFAULT = "false";
 
 	// HTTP related

--- a/common-utils/src/main/java/eu/arrowhead/common/Defaults.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/Defaults.java
@@ -1,0 +1,65 @@
+package eu.arrowhead.common;
+
+import eu.arrowhead.common.collector.HttpCollectorMode;
+import eu.arrowhead.common.http.filter.authentication.AuthenticationPolicy;
+import eu.arrowhead.common.http.filter.authorization.ManagementPolicy;
+
+public class Defaults {
+
+	//=================================================================================================
+	// members
+
+	// Global
+
+	public static final String MAX_PAGE_SIZE_DEFAULT = "1000";
+
+	// System related
+
+	public static final String SERVER_ADDRESS_DEFAULT = "";
+	public static final String SERVER_PORT_DEFAULT = "0"; // just to avoid NullPointerException
+	public static final String DOMAIN_NAME_DEFAULT = "";
+	public static final String SERVICEREGISTRY_ADDRESS_DEFAULT = Constants.LOCALHOST;
+	public static final String SERVICEREGISTRY_PORT_DEFAULT = "8443";
+	public static final String AUTHENTICATION_POLICY_DEFAULT = AuthenticationPolicy.CERTIFICATE_VALUE;
+	public static final String MANAGEMENT_POLICY_DEFAULT = ManagementPolicy.SYSOP_ONLY_VALUE;
+	public static final String MANAGEMENT_WHITELIST_DEFAULT = "\"\"";
+	public static final String ALLOW_SELF_ADDRESSING_DEFAULT = "true";
+	public static final String ALLOW_NON_ROUTABLE_ADDRESSING_DEFAULT = "true";
+	public static final String HTTP_COLLECTOR_MODE_DEFAULT = HttpCollectorMode.SR_AND_ORCH_VALUE;
+	public static final String ENABLE_BLACKLIST_FILTER_DEFAULT = "false";
+	public static final String FORCE_BLACKLIST_FILTER_DEFAULT = "true";
+
+	// SSL related
+
+	public static final String SERVER_SSL_ENABLED_DEFAULT = "false";
+	public static final String KEYSTORE_TYPE_DEFAULT = Constants.PKCS12;
+	public static final String KEYSTORE_PATH_DEFAULT = "";
+	public static final String KEYSTORE_PASSWORD_DEFAULT = "";
+	public static final String KEY_PASSWORD_DEFAULT = "";
+	public static final String KEY_ALIAS_DEFAULT = "";
+	public static final String TRUSTSTORE_PATH_DEFAULT = "";
+	public static final String TRUSTSTORE_PASSWORD_DEFAULT = "";
+	public static final String DISABLE_HOSTNAME_VERIFIER_DEFAULT = "false";
+
+	// HTTP related
+
+	public static final String HTTP_CLIENT_CONNECTION_TIMEOUT_DEFAULT = "30000";
+	public static final String HTTP_CLIENT_SOCKET_TIMEOUT_DEFAULT = "30000";
+	public static final String LOG_ALL_REQUEST_AND_RESPONSE_DEFAULT = "false";
+	public static final String CORS_ORIGIN_PATTERN_DEFAULT = "*";
+
+	// MQTT related
+
+	public static final String MQTT_API_ENABLED_DEFAULT = "false";
+	public static final String MQTT_BROKER_ADDRESS_DEFAULT = "";
+	public static final String MQTT_BROKER_PORT_DEFAULT = "1883";
+	public static final String MQTT_CLIENT_PASSWORD_DEFAULT = "";
+
+	//=================================================================================================
+	// assistant methods
+
+	//-------------------------------------------------------------------------------------------------
+	protected Defaults() {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/common-utils/src/main/java/eu/arrowhead/common/Defaults.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/Defaults.java
@@ -21,6 +21,7 @@ public class Defaults {
 	public static final String SERVICEREGISTRY_ADDRESS_DEFAULT = Constants.LOCALHOST;
 	public static final String SERVICEREGISTRY_PORT_DEFAULT = "8443";
 	public static final String AUTHENTICATION_POLICY_DEFAULT = AuthenticationPolicy.CERTIFICATE_VALUE;
+	public static final String ENABLE_MANAGEMENT_FILTER_DEFAULT = "false";
 	public static final String MANAGEMENT_POLICY_DEFAULT = ManagementPolicy.SYSOP_ONLY_VALUE;
 	public static final String MANAGEMENT_WHITELIST_DEFAULT = "\"\"";
 	public static final String ALLOW_SELF_ADDRESSING_DEFAULT = "true";
@@ -28,6 +29,7 @@ public class Defaults {
 	public static final String HTTP_COLLECTOR_MODE_DEFAULT = HttpCollectorMode.SR_AND_ORCH_VALUE;
 	public static final String ENABLE_BLACKLIST_FILTER_DEFAULT = "false";
 	public static final String FORCE_BLACKLIST_FILTER_DEFAULT = "true";
+	public static final String SERVICE_ADDRESS_ALIAS_DEFAULT = "\"\"";
 
 	// SSL related
 

--- a/common-utils/src/main/java/eu/arrowhead/common/SSLProperties.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/SSLProperties.java
@@ -16,25 +16,25 @@ public class SSLProperties {
 	@Value(Constants.$SERVER_SSL_ENABLED_WD)
 	private boolean sslEnabled;
 
-	@Value(Constants.$KEYSTORE_TYPE_WD)
+	@Value(Constants.$SERVER_SSL_KEY__STORE_TYPE_WD)
 	private String keyStoreType;
 
-	@Value(Constants.$KEYSTORE_PATH_WD)
+	@Value(Constants.$SERVER_SSL_KEY__STORE_WD)
 	private Resource keyStore;
 
-	@Value(Constants.$KEYSTORE_PASSWORD_WD)
+	@Value(Constants.$SERVER_SSL_KEY__STORE__PASSWORD_WD)
 	private String keyStorePassword;
 
-	@Value(Constants.$KEY_PASSWORD_WD)
+	@Value(Constants.$SERVER_SSL_KEY__PASSWORD_WD)
 	private String keyPassword;
 
-	@Value(Constants.$KEY_ALIAS_WD)
+	@Value(Constants.$SERVER_SSL_KEY__ALIAS_WD)
 	private String keyAlias;
 
-	@Value(Constants.$TRUSTSTORE_PATH_WD)
+	@Value(Constants.$SERVER_SSL_TRUST__STORE_WD)
 	private Resource trustStore;
 
-	@Value(Constants.$TRUSTSTORE_PASSWORD_WD)
+	@Value(Constants.$SERVER_SSL_TRUST__STORE__PASSWORD_WD)
 	private String trustStorePassword;
 
 	//=================================================================================================

--- a/common-utils/src/main/java/eu/arrowhead/common/SystemInfo.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/SystemInfo.java
@@ -32,6 +32,7 @@ public abstract class SystemInfo {
 
 	private static final String DEFAULT_SUFFIX = "DEFAULT";
 	private static final String KEY_DELIMITER_REGEX = "\\.";
+	private static final String KEY_HYPHEN_REGEX = "-";
 	private static final String FIELD_DELIMITER = "_";
 
 	@Value(Constants.$SERVER_ADDRESS)
@@ -198,6 +199,7 @@ public abstract class SystemInfo {
 		return key.trim()
 				.toUpperCase()
 				.replaceAll(KEY_DELIMITER_REGEX, FIELD_DELIMITER)
+				.replaceAll(KEY_HYPHEN_REGEX, FIELD_DELIMITER + FIELD_DELIMITER)
 				+ FIELD_DELIMITER
 				+ DEFAULT_SUFFIX;
 	}

--- a/common-utils/src/main/java/eu/arrowhead/common/SystemInfo.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/SystemInfo.java
@@ -94,6 +94,9 @@ public abstract class SystemInfo {
 	// assistant methods
 
 	//-------------------------------------------------------------------------------------------------
+	protected abstract PublicConfigurationKeysAndDefaults getPublicConfigurationKeysAndDefaults();
+
+	//-------------------------------------------------------------------------------------------------
 	protected void customInit() {
 	};
 
@@ -214,5 +217,12 @@ public abstract class SystemInfo {
 	//-------------------------------------------------------------------------------------------------
 	public boolean isSslEnabled() {
 		return sslProperties != null && sslProperties.isSslEnabled();
+	}
+
+	//=================================================================================================
+	// nested structures
+
+	//-------------------------------------------------------------------------------------------------
+	public record PublicConfigurationKeysAndDefaults(List<String> configKeys, Class<?> defaultsClass) {
 	}
 }

--- a/common-utils/src/main/java/eu/arrowhead/common/collector/HttpCollectorMode.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/collector/HttpCollectorMode.java
@@ -1,5 +1,10 @@
 package eu.arrowhead.common.collector;
 
 public enum HttpCollectorMode {
-	SR_ONLY, SR_AND_ORCH
+	SR_ONLY, SR_AND_ORCH;
+	
+	//=================================================================================================
+	// members
+	
+	public static final String SR_AND_ORCH_VALUE = "SR_AND_ORCH"; // right side must be a constant expression
 }

--- a/common-utils/src/main/java/eu/arrowhead/common/collector/HttpCollectorMode.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/collector/HttpCollectorMode.java
@@ -2,9 +2,9 @@ package eu.arrowhead.common.collector;
 
 public enum HttpCollectorMode {
 	SR_ONLY, SR_AND_ORCH;
-	
+
 	//=================================================================================================
 	// members
-	
+
 	public static final String SR_AND_ORCH_VALUE = "SR_AND_ORCH"; // right side must be a constant expression
 }

--- a/common-utils/src/main/java/eu/arrowhead/common/http/HttpService.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/http/HttpService.java
@@ -368,14 +368,14 @@ public class HttpService {
 		logger.debug("createSSLContext started...");
 
 		final String messageNotDefined = " is not defined.";
-		Assert.isTrue(!Utilities.isEmpty(sslProperties.getKeyStoreType()), Constants.KEYSTORE_TYPE + messageNotDefined);
-		Assert.notNull(sslProperties.getKeyStore(), Constants.KEYSTORE_PATH + messageNotDefined);
-		Assert.isTrue(sslProperties.getKeyStore().exists(), Constants.KEYSTORE_PATH + " file is not found.");
-		Assert.notNull(sslProperties.getKeyStorePassword(), Constants.KEYSTORE_PASSWORD + messageNotDefined);
-		Assert.notNull(sslProperties.getKeyPassword(), Constants.KEY_PASSWORD + messageNotDefined);
-		Assert.notNull(sslProperties.getTrustStore(), Constants.TRUSTSTORE_PATH + messageNotDefined);
-		Assert.isTrue(sslProperties.getTrustStore().exists(), Constants.TRUSTSTORE_PATH + " file is not found.");
-		Assert.notNull(sslProperties.getTrustStorePassword(), Constants.TRUSTSTORE_PASSWORD + messageNotDefined);
+		Assert.isTrue(!Utilities.isEmpty(sslProperties.getKeyStoreType()), Constants.SERVER_SSL_KEY__STORE__TYPE + messageNotDefined);
+		Assert.notNull(sslProperties.getKeyStore(), Constants.SERVER_SSL_KEY__STORE + messageNotDefined);
+		Assert.isTrue(sslProperties.getKeyStore().exists(), Constants.SERVER_SSL_KEY__STORE + " file is not found.");
+		Assert.notNull(sslProperties.getKeyStorePassword(), Constants.SERVER_SSL_KEY__STORE__PASSWORD + messageNotDefined);
+		Assert.notNull(sslProperties.getKeyPassword(), Constants.SERVER_SSL_KEY__PASSWORD + messageNotDefined);
+		Assert.notNull(sslProperties.getTrustStore(), Constants.SERVER_SSL_TRUST__STORE + messageNotDefined);
+		Assert.isTrue(sslProperties.getTrustStore().exists(), Constants.SERVER_SSL_TRUST__STORE + " file is not found.");
+		Assert.notNull(sslProperties.getTrustStorePassword(), Constants.SERVER_SSL_TRUST__STORE__PASSWORD + messageNotDefined);
 
 		final KeyStore keyStore = KeyStore.getInstance(sslProperties.getKeyStoreType());
 		keyStore.load(sslProperties.getKeyStore().getInputStream(), sslProperties.getKeyStorePassword().toCharArray());

--- a/common-utils/src/main/java/eu/arrowhead/common/http/filter/authentication/AuthenticationPolicy.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/http/filter/authentication/AuthenticationPolicy.java
@@ -2,4 +2,9 @@ package eu.arrowhead.common.http.filter.authentication;
 
 public enum AuthenticationPolicy {
 	DECLARED, CERTIFICATE, OUTSOURCED;
+
+	//=================================================================================================
+	// members
+
+	public static final String CERTIFICATE_VALUE = "CERTIFICATE"; // right side must be a constant expression
 }

--- a/common-utils/src/main/java/eu/arrowhead/common/http/filter/authorization/ManagementPolicy.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/http/filter/authorization/ManagementPolicy.java
@@ -1,5 +1,10 @@
 package eu.arrowhead.common.http.filter.authorization;
 
 public enum ManagementPolicy {
-	SYSOP_ONLY, WHITELIST, AUTHORIZATION
+	SYSOP_ONLY, WHITELIST, AUTHORIZATION;
+
+	//=================================================================================================
+	// members
+
+	public static final String SYSOP_ONLY_VALUE = "SYSOP_ONLY"; // right side must be a constant expression
 }

--- a/common-utils/src/main/java/eu/arrowhead/common/init/ApplicationInitListener.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/init/ApplicationInitListener.java
@@ -167,10 +167,10 @@ public abstract class ApplicationInitListener {
 		logger.debug("initializeKeyStore started...");
 		Assert.isTrue(sysInfo.isSslEnabled(), "SSL is not enabled");
 		final String messageNotDefined = " is not defined";
-		Assert.isTrue(!Utilities.isEmpty(sysInfo.getSslProperties().getKeyStoreType()), Constants.KEYSTORE_TYPE + messageNotDefined);
-		Assert.notNull(sysInfo.getSslProperties().getKeyStore(), Constants.KEYSTORE_PATH + messageNotDefined);
-		Assert.isTrue(sysInfo.getSslProperties().getKeyStore().exists(), Constants.KEYSTORE_PATH + " file is not found");
-		Assert.notNull(sysInfo.getSslProperties().getKeyStorePassword(), Constants.KEYSTORE_PASSWORD + messageNotDefined);
+		Assert.isTrue(!Utilities.isEmpty(sysInfo.getSslProperties().getKeyStoreType()), Constants.SERVER_SSL_KEY__STORE__TYPE + messageNotDefined);
+		Assert.notNull(sysInfo.getSslProperties().getKeyStore(), Constants.SERVER_SSL_KEY__STORE + messageNotDefined);
+		Assert.isTrue(sysInfo.getSslProperties().getKeyStore().exists(), Constants.SERVER_SSL_KEY__STORE + " file is not found");
+		Assert.notNull(sysInfo.getSslProperties().getKeyStorePassword(), Constants.SERVER_SSL_KEY__STORE__PASSWORD + messageNotDefined);
 
 		final KeyStore keystore = KeyStore.getInstance(sysInfo.getSslProperties().getKeyStoreType());
 		keystore.load(sysInfo.getSslProperties().getKeyStore().getInputStream(), sysInfo.getSslProperties().getKeyStorePassword().toCharArray());

--- a/common-utils/src/main/java/eu/arrowhead/common/mqtt/MqttService.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/mqtt/MqttService.java
@@ -125,14 +125,14 @@ public class MqttService {
 		logger.debug("sslSettings started");
 
 		final String messageNotDefined = " is not defined";
-		Assert.isTrue(!Utilities.isEmpty(sslProperties.getKeyStoreType()), Constants.KEYSTORE_TYPE + messageNotDefined);
-		Assert.notNull(sslProperties.getKeyStore(), Constants.KEYSTORE_PATH + messageNotDefined);
-		Assert.isTrue(sslProperties.getKeyStore().exists(), Constants.KEYSTORE_PATH + " file is not found");
-		Assert.notNull(sslProperties.getKeyStorePassword(), Constants.KEYSTORE_PASSWORD + messageNotDefined);
-		Assert.notNull(sslProperties.getKeyPassword(), Constants.KEY_PASSWORD + messageNotDefined);
-		Assert.notNull(sslProperties.getTrustStore(), Constants.TRUSTSTORE_PATH + messageNotDefined);
-		Assert.isTrue(sslProperties.getTrustStore().exists(), Constants.TRUSTSTORE_PATH + " file is not found");
-		Assert.notNull(sslProperties.getTrustStorePassword(), Constants.TRUSTSTORE_PASSWORD + messageNotDefined);
+		Assert.isTrue(!Utilities.isEmpty(sslProperties.getKeyStoreType()), Constants.SERVER_SSL_KEY__STORE__TYPE + messageNotDefined);
+		Assert.notNull(sslProperties.getKeyStore(), Constants.SERVER_SSL_KEY__STORE + messageNotDefined);
+		Assert.isTrue(sslProperties.getKeyStore().exists(), Constants.SERVER_SSL_KEY__STORE + " file is not found");
+		Assert.notNull(sslProperties.getKeyStorePassword(), Constants.SERVER_SSL_KEY__STORE__PASSWORD + messageNotDefined);
+		Assert.notNull(sslProperties.getKeyPassword(), Constants.SERVER_SSL_KEY__PASSWORD + messageNotDefined);
+		Assert.notNull(sslProperties.getTrustStore(), Constants.SERVER_SSL_TRUST__STORE + messageNotDefined);
+		Assert.isTrue(sslProperties.getTrustStore().exists(), Constants.SERVER_SSL_TRUST__STORE + " file is not found");
+		Assert.notNull(sslProperties.getTrustStorePassword(), Constants.SERVER_SSL_TRUST__STORE__PASSWORD + messageNotDefined);
 
 		final KeyStore keyStore = KeyStore.getInstance(sslProperties.getKeyStoreType());
 		keyStore.load(sslProperties.getKeyStore().getInputStream(), sslProperties.getKeyStorePassword().toCharArray());

--- a/common-utils/src/main/java/eu/arrowhead/common/service/ConfigService.java
+++ b/common-utils/src/main/java/eu/arrowhead/common/service/ConfigService.java
@@ -11,6 +11,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
+import eu.arrowhead.common.SystemInfo;
 import eu.arrowhead.common.Utilities;
 import eu.arrowhead.common.exception.InvalidParameterException;
 import eu.arrowhead.common.service.validation.ConfigValidation;
@@ -28,26 +29,33 @@ public class ConfigService {
 	@Autowired
 	private Environment environment;
 
+	@Autowired
+	private SystemInfo sysInfo;
+
 	private final Logger logger = LogManager.getLogger(this.getClass());
 
 	//=================================================================================================
 	// methods
 
 	//-------------------------------------------------------------------------------------------------
-	public KeyValuesDTO getConfig(final List<String> keys, final List<String> forbiddenKeys, final String origin) {
+	public KeyValuesDTO getConfig(final List<String> keys, final String origin) {
 		logger.debug("getConfig started");
-		Assert.notNull(forbiddenKeys, "forbiddenKeys is null");
 		Assert.isTrue(!Utilities.isEmpty(origin), "origin is empty");
 
 		try {
 			final List<String> normalized = validator.validateAndNormalizeConfigKeyList(keys);
+			final Map<String, String> configDefaultsMap = sysInfo.getConfigDefaultsMap();
 
 			final Map<String, String> result = new HashMap<>();
-
 			for (final String key : normalized) {
-				if (!forbiddenKeys.contains(key) && !Utilities.isEmpty(environment.getProperty(key))) {
-					result.put(key, environment.getProperty(key));
+				if (configDefaultsMap.containsKey(key)) {
+					result.put(key, configDefaultsMap.get(key)); // default value
+					if (!Utilities.isEmpty(environment.getProperty(key))) {
+						result.put(key, environment.getProperty(key)); // override default
+					}
 				}
+
+				// not public config => ignore
 			}
 
 			return convertConfigMapToDTO(result);


### PR DESCRIPTION
Implementation of issue #58

After merging this to development, we have to adjust existing systems to the changes:

@Katinka666 Blacklist
@rbocsi Authentication
@borditamas Service Orchestration (also checking SR, because there can be new properties)

Adjusting involves:

- Creating a system-specific *Defaults class for the system-specific defaults which is a subclass of the Defaults class;
- Modifying the system-specific *Constants class using the defaults in EL expression, also deleting the FORBIDDEN_KEYS list;
- Implementing a new method in system-specific *SystemInfo class by providing a set of public config keys and the class object of the above-mentioned *Defaults class;
- The signature of getConfig service is changed, so have some easy modification in the API classes (both HTTP and MQTT);

See example in the Service Registry